### PR TITLE
Don't use Constants for Text Domains

### DIFF
--- a/src/Settings.php
+++ b/src/Settings.php
@@ -221,8 +221,8 @@ if ( ! class_exists( Settings::class ) ) {
 				// TODO: Settings heading end.
 				'a_setting' => [ // TODO
 					'type'            => 'text',
-					'label'           => esc_html__( 'xxx try this', PLUGIN_TEXT_DOMAIN ),
-					'tooltip'         => sprintf( esc_html__( 'Enter your custom URL, including "http://" or "https://", for example %s.', PLUGIN_TEXT_DOMAIN ), '<code>https://wpshindig.com/events/</code>' ),
+					'label'           => esc_html__( 'xxx try this', 'tribe-ext-extension-template' ),
+					'tooltip'         => sprintf( esc_html__( 'Enter your custom URL, including "http://" or "https://", for example %s.', 'tribe-ext-extension-template' ), '<code>https://wpshindig.com/events/</code>' ),
 					'validation_type' => 'html',
 				],
 			];
@@ -263,10 +263,10 @@ if ( ! class_exists( Settings::class ) ) {
 		 * @return string
 		 */
 		private function get_example_intro_text() {
-			$result = '<h3>' . esc_html_x( 'Example Extension Setup', 'Settings header', PLUGIN_TEXT_DOMAIN ) . '</h3>';
+			$result = '<h3>' . esc_html_x( 'Example Extension Setup', 'Settings header', 'tribe-ext-extension-template' ) . '</h3>';
 			$result .= '<div style="margin-left: 20px;">';
 			$result .= '<p>';
-			$result .= esc_html_x( 'Some text here about this settings section.', 'Settings', PLUGIN_TEXT_DOMAIN );
+			$result .= esc_html_x( 'Some text here about this settings section.', 'Settings', 'tribe-ext-extension-template' );
 			$result .= '</p>';
 			$result .= '</div>';
 

--- a/src/Settings_Helper.php
+++ b/src/Settings_Helper.php
@@ -127,7 +127,7 @@ if ( ! class_exists( Settings_Helper::class ) ) {
 					$misc_heading = [
 						'tribeMiscSettings' => [
 							'type' => 'html',
-							'html' => '<h3>' . esc_html__( 'Miscellaneous Settings', PLUGIN_TEXT_DOMAIN ) . '</h3>',
+							'html' => '<h3>' . esc_html__( 'Miscellaneous Settings', 'tribe-ext-extension-template' ) . '</h3>',
 						],
 					];
 					$fields       = Tribe__Main::array_insert_before_key( 'tribe-form-content-end', $fields, $misc_heading );

--- a/tribe-ext-extension-template.php
+++ b/tribe-ext-extension-template.php
@@ -29,14 +29,6 @@ use Tribe__Autoloader;
 use Tribe__Dependency;
 use Tribe__Extension;
 
-/**
- * Define Constants
- */
-
-if ( ! defined( __NAMESPACE__ . '\NS' ) ) {
-	define( __NAMESPACE__ . '\NS', __NAMESPACE__ . '\\' );
-}
-
 // Do not load unless Tribe Common is fully loaded and our class does not yet exist.
 if (
 	class_exists( 'Tribe__Extension' )
@@ -224,7 +216,7 @@ if (
 				$this->class_loader = new Tribe__Autoloader;
 				$this->class_loader->set_dir_separator( '\\' );
 				$this->class_loader->register_prefix(
-					NS,
+					__NAMESPACE__ . '\\',
 					__DIR__ . DIRECTORY_SEPARATOR . 'src'
 				);
 			}

--- a/tribe-ext-extension-template.php
+++ b/tribe-ext-extension-template.php
@@ -37,11 +37,6 @@ if ( ! defined( __NAMESPACE__ . '\NS' ) ) {
 	define( __NAMESPACE__ . '\NS', __NAMESPACE__ . '\\' );
 }
 
-if ( ! defined( NS . 'PLUGIN_TEXT_DOMAIN' ) ) {
-	// `Tribe\Extensions\Example\PLUGIN_TEXT_DOMAIN` is defined
-	define( NS . 'PLUGIN_TEXT_DOMAIN', 'tribe-ext-extension-template' );
-}
-
 // Do not load unless Tribe Common is fully loaded and our class does not yet exist.
 if (
 	class_exists( 'Tribe__Extension' )
@@ -128,7 +123,7 @@ if (
 		 * @return string
 		 */
 		private function get_options_prefix() {
-			return (string) str_replace( '-', '_', PLUGIN_TEXT_DOMAIN );
+			return (string) str_replace( '-', '_', 'tribe-ext-extension-template' );
 		}
 
 		/**
@@ -150,7 +145,7 @@ if (
 		public function init() {
 			// Load plugin textdomain
 			// Don't forget to generate the 'languages/tribe-ext-extension-template.pot' file
-			load_plugin_textdomain( PLUGIN_TEXT_DOMAIN, false, basename( dirname( __FILE__ ) ) . '/languages/' );
+			load_plugin_textdomain( 'tribe-ext-extension-template', false, basename( dirname( __FILE__ ) ) . '/languages/' );
 
 			if ( ! $this->php_version_check() ) {
 				return;
@@ -202,13 +197,13 @@ if (
 				) {
 					$message = '<p>';
 
-					$message .= sprintf( __( '%s requires PHP version %s or newer to work. Please contact your website host and inquire about updating PHP.', PLUGIN_TEXT_DOMAIN ), $this->get_name(), $php_required_version );
+					$message .= sprintf( __( '%s requires PHP version %s or newer to work. Please contact your website host and inquire about updating PHP.', 'tribe-ext-extension-template' ), $this->get_name(), $php_required_version );
 
 					$message .= sprintf( ' <a href="%1$s">%1$s</a>', 'https://wordpress.org/about/requirements/' );
 
 					$message .= '</p>';
 
-					tribe_notice( PLUGIN_TEXT_DOMAIN . '-php-version', $message, [ 'type' => 'error' ] );
+					tribe_notice( 'tribe-ext-extension-template' . '-php-version', $message, [ 'type' => 'error' ] );
 				}
 
 				return false;
@@ -247,7 +242,7 @@ if (
 
 			$message .= sprintf( '<p><strong>Bonus!</strong> Get one of our own custom option values: %s</p><p><em>See the code to learn more.</em></p>', $this->get_one_custom_option() );
 
-			tribe_notice( PLUGIN_TEXT_DOMAIN . '-hello-world', $message, [ 'type' => 'info' ] );
+			tribe_notice( 'tribe-ext-extension-template' . '-hello-world', $message, [ 'type' => 'info' ] );
 		}
 
 		/**


### PR DESCRIPTION
Following the WordPress plugin developer handbook, removes the usage of a variable or constant for the text domain.

From the Handbook:

> Do not use variable names or constants for the text domain portion of a gettext function. Do not do this as a shortcut: __( ‘Translate me.’ , $text_domain );

Reference: https://developer.wordpress.org/plugins/internationalization/how-to-internationalize-your-plugin/#text-domains